### PR TITLE
ci: change trigger only to PR against main

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,8 +1,6 @@
 name: Smoke Tests
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
This PR changes the smoke.yml file to adjust trigger only on PR against main branch